### PR TITLE
Container image update to GA versions

### DIFF
--- a/src/Microsoft.Azure.VirtualKubelet.Edge.Provider/EdgeProvider.cs
+++ b/src/Microsoft.Azure.VirtualKubelet.Edge.Provider/EdgeProvider.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.VirtualKubelet.Edge.Provider
                             RestartPolicy = "always",
                             Settings = new EdgeModuleSettings
                             {
-                                Image = "microsoft/azureiotedge-agent:1.0-preview",
+                                Image = "mcr.microsoft.com/azureiotedge-agent:1.0",
                                 CreateOptions = "{}"
                             }
                         }
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.VirtualKubelet.Edge.Provider
                             RestartPolicy = "always",
                             Settings = new EdgeModuleSettings
                             {
-                                Image = "microsoft/azureiotedge-hub:1.0-preview",
+                                Image = "mcr.microsoft.com/azureiotedge-hub:1.0",
                                 CreateOptions = "{}"
                             }
                         }


### PR DESCRIPTION
Updated the container image references to the GA versions. Referencing to the following issue https://github.com/Azure/iot-edge-virtual-kubelet-provider/issues/18

So, after merging this PR, there must be a new container build and push for microsoft/iot-edge-vk-provider to roll-out the changes.

Container registry credential is not solved with the PR only the incompatible container images for IoT Edge GA.