### PR TITLE
Adding CPU and memory resource requests and limits

### DIFF
--- a/src/charts/iot-edge-connector/templates/clusterrolebinding.yaml
+++ b/src/charts/iot-edge-connector/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 {{ if .Values.rbac.install }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: "rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}"
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "edge-provider.fullname" . }}-role-binding
 subjects:
 - kind: ServiceAccount
   name: {{ template "edge-provider.fullname" . }}-service-account
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/src/charts/iot-edge-connector/templates/deployment.yaml
+++ b/src/charts/iot-edge-connector/templates/deployment.yaml
@@ -35,10 +35,16 @@ spec:
           httpGet:
             path: /
             port: {{ .Values.edgeproviderimage.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /
             port: {{ .Values.edgeproviderimage.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: {{ .Values.edgeproviderimage.requests.cpu }}

--- a/src/charts/iot-edge-connector/templates/deployment.yaml
+++ b/src/charts/iot-edge-connector/templates/deployment.yaml
@@ -39,6 +39,13 @@ spec:
           httpGet:
             path: /
             port: {{ .Values.edgeproviderimage.port }}
+        resources:
+          requests:
+            cpu: {{ .Values.edgeproviderimage.requests.cpu }}
+            memory: {{ .Values.edgeproviderimage.requests.memory }}
+          limits:
+            cpu: {{ .Values.edgeproviderimage.limits.cpu }}
+            memory: {{ .Values.edgeproviderimage.limits.memory }}
       - name: virtualkubelet
         image: "{{ .Values.vkimage.repository }}:{{ .Values.vkimage.tag }}"
         imagePullPolicy: {{ .Values.vkimage.pullPolicy }}
@@ -63,6 +70,13 @@ spec:
           {{- end }}
           "--os", "{{ .Values.env.nodeOsType }}"
         ]
+        resources:
+          requests:
+            cpu: {{ .Values.vkimage.requests.cpu }}
+            memory: {{ .Values.vkimage.requests.memory }}
+          limits:
+            cpu: {{ .Values.vkimage.limits.cpu }}
+            memory: {{ .Values.vkimage.limits.memory }}
       serviceAccountName: {{ if .Values.rbac.install }} "{{ template "edge-provider.fullname" . }}-service-account" {{ end }}
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/src/charts/iot-edge-connector/values.yaml
+++ b/src/charts/iot-edge-connector/values.yaml
@@ -5,10 +5,22 @@ edgeproviderimage:
   port: 5000
   secretsStoreName: my-secrets
   secretKey: hub0-cs
+  requests:
+    cpu: 10m
+    memory: 120Mi
+  limits:
+    cpu: 100m
+    memory: 250Mi
 vkimage:
   repository: microsoft/virtual-kubelet
   tag: latest
   pullPolicy: Always
+  requests:
+    cpu: 10m
+    memory: 25Mi
+  limits:
+    cpu: 100m
+    memory: 100Mi
 env:
   nodeName: iot-edge-connector-hub0
   nodeOsType: Linux

--- a/src/charts/iot-edge-connector/values.yaml
+++ b/src/charts/iot-edge-connector/values.yaml
@@ -36,7 +36,6 @@ taint:
 # Install Default RBAC roles and bindings
 rbac:
   install: true
-  serviceAccountName: virtual-kubelet
   # RBAC api version (currently v1)
   apiVersion: v1
   # Cluster role reference


### PR DESCRIPTION
This PR adds default resource requests and limits for CPU and memory for both containers to the Helm chart. Additionally it implements another couple of changes:

- Adjustments to the ClusterRoleBinding
- Additional probe settings for the Deployment
- Clean up of an unused parameter in the values.yaml

Implementing Kubernetes best practices.