### PR TITLE
Changing logging level from Information to Warning for edgeprovider container

### DIFF
--- a/src/Microsoft.Azure.VirtualKubelet.Edge.Provider/appsettings.json
+++ b/src/Microsoft.Azure.VirtualKubelet.Edge.Provider/appsettings.json
@@ -8,7 +8,7 @@
     },
     "Console": {
       "LogLevel": {
-        "Default": "Information"
+        "Default": "Warning"
       }
     }
   }


### PR DESCRIPTION
This PR changes the logging level of the edgeprovider container from Information to Warning to only receive necessary logging information in the container log output such as warnings and errors. Information is a to noisy level here and just eats up memory.